### PR TITLE
Add Elixir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ so if you in an `actionview` file, it'll run
 * Runs `ruby -Ilib $current_file`
 * runs `rake TEST=$current_file` when developing a gem with Minitest.
 
-If you're testing Javascript, smartest:
+If you're testing **Javascript**, smartest:
 
 * checks if it's a Konacha spec and runs it using Zeus or Bundler
 (whichever is available).
 * checks if `phantomjs` can be used based on the presence of `tests/runner.js`.
   In case it's QUnit, it'll run only the current file.
 * runs `rake` if it doesn't know what to do (e.g `QUnit`)
+
+Case you're running **Elixir** code, smartest will:
+* Run the test with `Mix`, case you used it's extension convention under a Mix
+project;
+* Run the test with `elixir`, in which case you'll need to add `ExUnit.start` to
+the top of your test.
 
 ### Usage
 

--- a/plugin/smartest.vim
+++ b/plugin/smartest.vim
@@ -27,7 +27,7 @@ function! RunTestFile(...)
   endif
 
   " Run the tests for the previously-marked file.
-  let in_test_file = match(expand("%"), '\(.feature\|_spec.rb\|_test.rb\|_test.js\|_spec.js\)')
+  let in_test_file = match(expand("%"), '\(.feature\|_spec.rb\|_test.rb\|_test.js\|_spec.js\|_test.exs\|_test.ex\)')
 
   if in_test_file >= 0
     call SetTestFile(command_suffix)
@@ -248,6 +248,17 @@ function! RunTests(filename)
     else
       :silent !echo "Using vanilla rspec outside Rails"
       exec ":!rspec -O ~/.rspec --color --format progress --no-drb --order random " . a:filename
+    end
+  " ELIXIR
+  elseif match(a:filename, '\(._test.ex\|_test.exs\)') >= 0
+    if match(a:filename, '\(._test.exs\)') >= 0
+      " Mix
+      :silent !echo "Using ExUnit with Mix"
+      exec ":!mix test " . a:filename
+    else
+      " ExUnit
+      :silent !echo "Using ExUnit outside Mix"
+      exec ":!elixir " . a:filename
     end
   end
 endfunction


### PR DESCRIPTION
Once you're comfortable with a tool, you wanna use it to every new thing you try, that's why I decided to add elixir to **smartest**.

It will work like it always have, same mapped keys, and choose which way to run the test (compiling or interpreting), based on the code you're current working.
